### PR TITLE
feat(temp-spike): battery tweaks for TP96x

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -28,7 +28,7 @@ UNPACK_TEMP_HUMID = Struct("<hB").unpack
 UNPACK_SPIKE_TEMP = Struct("<BHHH").unpack
 
 TP96_MAX_BAT = 2880
-TP96_MIN_BAT = 1600  # ??
+TP96_MIN_BAT = 2000  # ??
 
 
 class ThermoProBluetoothDeviceData(BluetoothData):
@@ -82,6 +82,8 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = ((battery - TP96_MIN_BAT) / bat_range) * 100
+            if battery_percent > 100:
+                battery_percent = 100
             self.update_predefined_sensor(
                 SensorLibrary.TEMPERATURE__CELSIUS,
                 internal_temp,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -339,7 +339,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=39,
+                native_value=11,
             ),
         },
         binary_entity_descriptions={},
@@ -405,7 +405,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=39,
+                native_value=11,
             ),
         },
         binary_entity_descriptions={},
@@ -475,7 +475,7 @@ def test_tp962r():
             DeviceKey(key="battery_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_2", device_id=None),
                 name="Probe 2 Battery",
-                native_value=100,
+                native_value=99,
             ),
         },
         binary_entity_descriptions={},
@@ -567,12 +567,12 @@ def test_tp962r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=77,
+                native_value=66,
             ),
             DeviceKey(key="battery_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_2", device_id=None),
                 name="Probe 2 Battery",
-                native_value=100,
+                native_value=99,
             ),
             DeviceKey(key="internal_temperature_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(


### PR DESCRIPTION
- Raised minimum battery constant from 1600 to 2000
- Clamped battery percent at 100
- Updated unit tests to reflect changes to battery calculation