### PR TITLE
Temp spike battery improvements

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -27,8 +27,12 @@ BATTERY_VALUE_TO_LEVEL = {
 UNPACK_TEMP_HUMID = Struct("<hB").unpack
 UNPACK_SPIKE_TEMP = Struct("<BHHH").unpack
 
+# TP96x battery values appear to be a voltage reading, probably in millivolts.
+# This means that calculating battery life from it should be a non-linear
+# function.
+# TODO: Find a a reasonalbe approximation of the voltage discharge curve.
 TP96_MAX_BAT = 2880
-TP96_MIN_BAT = 2000  # ??
+TP96_MIN_BAT = 1850
 
 
 class ThermoProBluetoothDeviceData(BluetoothData):
@@ -82,6 +86,7 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = ((battery - TP96_MIN_BAT) / bat_range) * 100
+            battery_percent = max(0, min(battery_percent, 100))
             if battery_percent > 100:
                 battery_percent = 100
             self.update_predefined_sensor(

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -90,8 +90,6 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = tp96_battery(battery_voltage)
-            if battery_percent > 100:
-                battery_percent = 100
             self.update_predefined_sensor(
                 SensorLibrary.TEMPERATURE__CELSIUS,
                 internal_temp,

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -36,9 +36,9 @@ UNPACK_SPIKE_TEMP = Struct("<BHHH").unpack
 # A*tanh(B*x+C)+D
 # Where A,B,C,D are the variables to optimize for.  This yielded the below function
 def tp96_battery(voltage: int) -> float:
-    raw = 0.52317286 * tanh(voltage / 273.624277936 - 8.76485439394) + 0.5106925
-    clamped = max(0, min(raw, 1))
-    return round(clamped * 100, 2)
+    raw = 52.317286 * tanh(voltage / 273.624277936 - 8.76485439394) + 51.06925
+    clamped = max(0, min(raw, 100))
+    return round(clamped, 2)
 
 
 class ThermoProBluetoothDeviceData(BluetoothData):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -339,7 +339,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=24,
+                native_value=9,
             ),
         },
         binary_entity_descriptions={},
@@ -405,7 +405,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=24,
+                native_value=9,
             ),
         },
         binary_entity_descriptions={},
@@ -567,7 +567,7 @@ def test_tp962r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=71,
+                native_value=82,
             ),
             DeviceKey(key="battery_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_2", device_id=None),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -339,7 +339,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=11,
+                native_value=24,
             ),
         },
         binary_entity_descriptions={},
@@ -405,7 +405,7 @@ def test_tp960r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=11,
+                native_value=24,
             ),
         },
         binary_entity_descriptions={},
@@ -475,7 +475,7 @@ def test_tp962r():
             DeviceKey(key="battery_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_2", device_id=None),
                 name="Probe 2 Battery",
-                native_value=99,
+                native_value=100.0,
             ),
         },
         binary_entity_descriptions={},
@@ -567,12 +567,12 @@ def test_tp962r():
             DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_1", device_id=None),
                 name="Probe 1 Battery",
-                native_value=66,
+                native_value=71,
             ),
             DeviceKey(key="battery_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery_probe_2", device_id=None),
                 name="Probe 2 Battery",
-                native_value=99,
+                native_value=100.0,
             ),
             DeviceKey(key="internal_temperature_probe_2", device_id=None): SensorValue(
                 device_key=DeviceKey(


### PR DESCRIPTION
I finally managed to capture readings from an entire discharge cycle of a TempSpike battery.  The battery reading sent by the device appears to be a reading in millivolts, and the discharge cycle is a non-linear function as you would expect in that situation.

To create a more accurate mapping of voltage to battery percentage, I used some machine learning to optimize a function in the form `A*tanh(B*x+C)+D` where A->D are variables that were optimized with TensorFlow.  (I chose that function format simply because I noticed that the curve from the readings looked fairly similar to a `tanh` curve).  This yielded a function whose output fit within about 1.8% of the actual data collected, which I think is good enough ;)

I also added clamping for _both_ minimum and maximum values, just in case.