### PR TITLE
Add range check for temperature and humidity

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 from math import tanh
 from struct import Struct
-from typing import Union
 
 from bluetooth_data_tools import short_address
 from bluetooth_sensor_state_data import BluetoothData


### PR DESCRIPTION
Adds a check to guard against physically impossible reported values. Temperatures below absolute zero, or humidity outside 0-100 %, likely are the result of an invalid received packet and should be disregarded (disregard entire packet, other data probably also wrong).