### PR TITLE
Add support for TP972S

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -48,7 +48,9 @@ def tp96_battery(voltage: int) -> float:
 class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
-    def _update_sensors(self, probe_one_indexed, internal_temp, ambient_temp, battery_percent):
+    def _update_sensors(
+        self, probe_one_indexed, internal_temp, ambient_temp, battery_percent
+    ):
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,
             internal_temp,
@@ -98,7 +100,7 @@ class ThermoProBluetoothDeviceData(BluetoothData):
 
         data_length = len(data)
 
-        if data_length == 23 and name.startswith(("TP97")):
+        if data_length == 23 and name.startswith("TP97"):
             # TP972 has a 23-byte format
             # It has an internal temp probe and an ambient temp probe
             try:
@@ -106,12 +108,14 @@ class ThermoProBluetoothDeviceData(BluetoothData):
                     probe_zero_indexed,
                     ambient_temp,
                     battery_voltage,
-                    _, # looks to be part of some temp range (min)
+                    _,  # looks to be part of some temp range (min)
                     internal_temp,
-                    _, # looks to be part of some temp range (max)
-                    _, _, _ # looks like a static id
+                    _,  # looks to be part of some temp range (max)
+                    _,
+                    _,
+                    _,  # looks like a static id
                 ) = UNPACK_SPIKE_PRO_TEMP(data)
-            except struct_error as ex:
+            except struct_error:
                 _LOGGER.error("Error parsing data from probe: %s", data)
                 return
 
@@ -119,7 +123,9 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = int(internal_temp) - 54
             ambient_temp = int(ambient_temp) - 54
             battery_percent = tp96_battery(battery_voltage)
-            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
+            self._update_sensors(
+                probe_one_indexed, internal_temp, ambient_temp, battery_percent
+            )
             return
 
         if data_length == 7 and name.startswith(("TP96", "TP97")):
@@ -140,7 +146,9 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = tp96_battery(battery_voltage)
-            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
+            self._update_sensors(
+                probe_one_indexed, internal_temp, ambient_temp, battery_percent
+            )
             return
 
         if data_length < 6:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -288,7 +288,7 @@ TP972S = make_bluetooth_service_info(
 )
 TP972S_2 = make_bluetooth_service_info(
     name="TP972S",
-    manufacturer_data={36096: b'\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8'},
+    manufacturer_data={36096: b"\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8"},
     service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
     address="aa:bb:cc:dd:ee:ff",
     rssi=-75,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,6 +276,26 @@ TP970R_2 = make_bluetooth_service_info(
     service_data={},
     source="local",
 )
+
+TP972S = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={29184: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8"},
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+TP972S_2 = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={36096: b'\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8'},
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
 TP357S_UPDATE_1 = make_bluetooth_service_info(
     name="TP357S (C890)",
     address="C3:18:C9:9C:C8:90",
@@ -1250,6 +1270,144 @@ def test_tp970r():
                 device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
                 name="Probe 1 Ambient Temperature",
                 native_value=22,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
+def test_tp972s():
+    parser = ThermoProBluetoothDeviceData()
+    assert parser.update(TP972S) == SensorUpdate(
+        title="TP972S EEFF",
+        devices={
+            None: SensorDeviceInfo(
+                name="TP972S",
+                model="TP972S",
+                manufacturer="ThermoPro",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(
+                key="internal_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(
+                key="ambient_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                name="Probe 1 Battery",
+                native_value=90.0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-75,
+            ),
+            DeviceKey(key="internal_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                name="Probe 1 Internal Temperature",
+                native_value=33,
+            ),
+            DeviceKey(key="ambient_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                name="Probe 1 Ambient Temperature",
+                native_value=60,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+    assert parser.update(TP972S_2) == SensorUpdate(
+        title="TP972S EEFF",
+        devices={
+            None: SensorDeviceInfo(
+                name="TP972S",
+                model="TP972S",
+                manufacturer="ThermoPro",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(
+                key="internal_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(
+                key="ambient_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                name="Probe 1 Battery",
+                native_value=95.0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-75,
+            ),
+            DeviceKey(key="internal_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                name="Probe 1 Internal Temperature",
+                native_value=74,
+            ),
+            DeviceKey(key="ambient_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                name="Probe 1 Ambient Temperature",
+                native_value=87,
             ),
         },
         binary_entity_descriptions={},


### PR DESCRIPTION
Looking at the data stream, the TP972S appears to supply a 23-byte format: 0: 0-index of probe
 1: 2-byte short ambient temp + 54
 3: 2-byte battery level (kept same calculation as for TP96x)
 5: 4-byte float for min internal temp read
 9: 4 byte float for internal temp read
13: 4-byte float for max internal temp read
17: 6-byte ID