### PR TITLE
feat: add support for TP972S

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -30,6 +30,7 @@ BATTERY_VALUE_TO_LEVEL = {
 
 UNPACK_TEMP_HUMID = Struct("<hB").unpack
 UNPACK_SPIKE_TEMP = Struct("<BHHH").unpack
+UNPACK_SPIKE_PRO_TEMP = Struct("<BHHfffHHH").unpack
 
 
 # TP96x battery values appear to be a voltage reading, probably in millivolts.
@@ -46,6 +47,27 @@ def tp96_battery(voltage: int) -> float:
 
 class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
+
+    def _update_sensors(self, probe_one_indexed, internal_temp, ambient_temp, battery_percent):
+        self.update_predefined_sensor(
+            SensorLibrary.TEMPERATURE__CELSIUS,
+            internal_temp,
+            key=f"internal_temperature_probe_{probe_one_indexed}",
+            name=f"Probe {probe_one_indexed} Internal Temperature",
+        )
+        self.update_predefined_sensor(
+            SensorLibrary.TEMPERATURE__CELSIUS,
+            ambient_temp,
+            key=f"ambient_temperature_probe_{probe_one_indexed}",
+            name=f"Probe {probe_one_indexed} Ambient Temperature",
+        )
+        self.set_precision(0)
+        self.update_predefined_sensor(
+            SensorLibrary.BATTERY__PERCENTAGE,
+            battery_percent,
+            key=f"battery_probe_{probe_one_indexed}",
+            name=f"Probe {probe_one_indexed} Battery",
+        )
 
     def _start_update(self, service_info: BluetoothServiceInfoBleak) -> None:
         """Update from BLE advertisement data."""
@@ -74,56 +96,57 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             + changed_manufacturer_data[last_id]
         )
 
-        if len(data) < 6:
+        data_length = len(data)
+
+        if data_length == 23 and name.startswith(("TP97")):
+            # TP972 has a 23-byte format
+            # It has an internal temp probe and an ambient temp probe
+            (
+                probe_zero_indexed,
+                ambient_temp,
+                battery_voltage,
+                _, # looks to be part of some temp range (min)
+                internal_temp,
+                _, # looks to be part of some temp range (max)
+                _, _, _ # looks like a static id
+            ) = UNPACK_SPIKE_PRO_TEMP(data)
+
+            probe_one_indexed = probe_zero_indexed + 1
+            internal_temp = int(internal_temp) - 54
+            ambient_temp = int(ambient_temp) - 54
+            battery_percent = tp96_battery(battery_voltage)
+            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
             return
 
-        if name.startswith(("TP96", "TP97")):
-            # TP96 has a different format
+        if data_length == 7 and name.startswith(("TP96", "TP97")):
+            # TP96 has a different format that is shared with TP970
             # It has an internal temp probe and an ambient temp probe
-            try:
-                (
-                    probe_zero_indexed,
-                    internal_temp,
-                    battery_voltage,
-                    ambient_temp,
-                ) = UNPACK_SPIKE_TEMP(data)
-            except struct_error:
-                _LOGGER.error("Error parsing data from probe: %s", data)
-                return
+            (
+                probe_zero_indexed,
+                internal_temp,
+                battery_voltage,
+                ambient_temp,
+            ) = UNPACK_SPIKE_TEMP(data)
 
             probe_one_indexed = probe_zero_indexed + 1
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = tp96_battery(battery_voltage)
-            self.update_predefined_sensor(
-                SensorLibrary.TEMPERATURE__CELSIUS,
-                internal_temp,
-                key=f"internal_temperature_probe_{probe_one_indexed}",
-                name=f"Probe {probe_one_indexed} Internal Temperature",
-            )
-            self.update_predefined_sensor(
-                SensorLibrary.TEMPERATURE__CELSIUS,
-                ambient_temp,
-                key=f"ambient_temperature_probe_{probe_one_indexed}",
-                name=f"Probe {probe_one_indexed} Ambient Temperature",
-            )
-            self.set_precision(0)
-            self.update_predefined_sensor(
-                SensorLibrary.BATTERY__PERCENTAGE,
-                battery_percent,
-                key=f"battery_probe_{probe_one_indexed}",
-                name=f"Probe {probe_one_indexed} Battery",
-            )
+            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
             return
 
         # TP357S seems to be in 6, TP397 and TP393 in 4
-        battery_byte = data[6] if len(data) == 7 else data[4]
-        if battery_byte in BATTERY_VALUE_TO_LEVEL:
-            self.update_predefined_sensor(
-                SensorLibrary.BATTERY__PERCENTAGE,
-                BATTERY_VALUE_TO_LEVEL[battery_byte],
-            )
+        if data_length >= 6 and name.startswith("TP3"):
+            battery_byte = data[6] if data_length == 7 else data[4]
+            if battery_byte in BATTERY_VALUE_TO_LEVEL:
+                self.update_predefined_sensor(
+                    SensorLibrary.BATTERY__PERCENTAGE,
+                    BATTERY_VALUE_TO_LEVEL[battery_byte],
+                )
 
-        (temp, humi) = UNPACK_TEMP_HUMID(data[1:4])
-        self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temp / 10)
-        self.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi)
+            (temp, humi) = UNPACK_TEMP_HUMID(data[1:4])
+            self.update_predefined_sensor(SensorLibrary.TEMPERATURE__CELSIUS, temp / 10)
+            self.update_predefined_sensor(SensorLibrary.HUMIDITY__PERCENTAGE, humi)
+            return
+
+        _LOGGER.error("Error parsing data from probe: %s", data)

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -49,7 +49,11 @@ class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
     def _update_sensors(
-        self, probe_one_indexed: int, internal_temp: int, ambient_temp: int, battery_percent: float
+        self,
+        probe_one_indexed: int,
+        internal_temp: int,
+        ambient_temp: int,
+        battery_percent: float,
     ) -> None:
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -48,7 +48,9 @@ def tp96_battery(voltage: int) -> float:
 class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
-    def _update_sensors(self, probe_one_indexed, internal_temp, ambient_temp, battery_percent) -> None:
+    def _update_sensors(
+        self, probe_one_indexed, internal_temp, ambient_temp, battery_percent
+    ) -> None:
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,
             internal_temp,

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -17,7 +17,7 @@ from bluetooth_data_tools import short_address
 from bluetooth_sensor_state_data import BluetoothData
 from sensor_state_data import SensorLibrary
 
-from habluetooth import BluetoothServiceInfoBleak
+from habluetooth import BluetoothServiceInfo, BluetoothServiceInfoBleak
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,9 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             name=f"Probe {probe_one_indexed} Battery",
         )
 
-    def _start_update(self, service_info: BluetoothServiceInfoBleak) -> None:
+    def _start_update(
+        self, service_info: BluetoothServiceInfo | BluetoothServiceInfoBleak
+    ) -> None:
         """Update from BLE advertisement data."""
         _LOGGER.debug("Parsing thermopro BLE advertisement data: %s", service_info)
         name = service_info.name

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -48,9 +48,7 @@ def tp96_battery(voltage: int) -> float:
 class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
-    def _update_sensors(
-        self, probe_one_indexed, internal_temp, ambient_temp, battery_percent
-    ):
+    def _update_sensors(self, probe_one_indexed, internal_temp, ambient_temp, battery_percent) -> None:
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,
             internal_temp,

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -49,7 +49,7 @@ class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
     def _update_sensors(
-        self, probe_one_indexed, internal_temp, ambient_temp, battery_percent
+        self, probe_one_indexed: int, internal_temp: int, ambient_temp: int, battery_percent: float
     ) -> None:
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from math import tanh
-from struct import Struct, error as struct_error
+from struct import Struct
 
 from bluetooth_data_tools import short_address
 from bluetooth_sensor_state_data import BluetoothData
@@ -48,7 +48,9 @@ def tp96_battery(voltage: int) -> float:
 class ThermoProBluetoothDeviceData(BluetoothData):
     """Date update for ThermoPro Bluetooth devices."""
 
-    def _update_sensors(self, probe_one_indexed, internal_temp, ambient_temp, battery_percent):
+    def _update_sensors(
+        self, probe_one_indexed, internal_temp, ambient_temp, battery_percent
+    ):
         self.update_predefined_sensor(
             SensorLibrary.TEMPERATURE__CELSIUS,
             internal_temp,
@@ -98,24 +100,28 @@ class ThermoProBluetoothDeviceData(BluetoothData):
 
         data_length = len(data)
 
-        if data_length == 23 and name.startswith(("TP97")):
+        if data_length == 23 and name.startswith("TP97"):
             # TP972 has a 23-byte format
             # It has an internal temp probe and an ambient temp probe
             (
                 probe_zero_indexed,
                 ambient_temp,
                 battery_voltage,
-                _, # looks to be part of some temp range (min)
+                _,  # looks to be part of some temp range (min)
                 internal_temp,
-                _, # looks to be part of some temp range (max)
-                _, _, _ # looks like a static id
+                _,  # looks to be part of some temp range (max)
+                _,
+                _,
+                _,  # looks like a static id
             ) = UNPACK_SPIKE_PRO_TEMP(data)
 
             probe_one_indexed = probe_zero_indexed + 1
             internal_temp = int(internal_temp) - 54
             ambient_temp = int(ambient_temp) - 54
             battery_percent = tp96_battery(battery_voltage)
-            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
+            self._update_sensors(
+                probe_one_indexed, internal_temp, ambient_temp, battery_percent
+            )
             return
 
         if data_length == 7 and name.startswith(("TP96", "TP97")):
@@ -132,7 +138,9 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             internal_temp = internal_temp - 30
             ambient_temp = ambient_temp - 30
             battery_percent = tp96_battery(battery_voltage)
-            self._update_sensors(probe_one_indexed, internal_temp, ambient_temp, battery_percent)
+            self._update_sensors(
+                probe_one_indexed, internal_temp, ambient_temp, battery_percent
+            )
             return
 
         # TP357S seems to be in 6, TP397 and TP393 in 4

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,6 +276,26 @@ TP970R_2 = make_bluetooth_service_info(
     service_data={},
     source="local",
 )
+
+TP972S = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={29184: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8"},
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+TP972S_2 = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={36096: b'\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8'},
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
 TP357S_UPDATE_1 = make_bluetooth_service_info(
     name="TP357S (C890)",
     address="C3:18:C9:9C:C8:90",
@@ -393,6 +413,31 @@ TP357S_UPDATE_4 = make_bluetooth_service_info(
         54722: b'\x00\x14"\x0b\x01',
         54978: b'\x00\x14"\x0b\x01',
         53186: b'\x00\x14"\x0b\x01',
+    },
+    service_data={},
+    service_uuids=[],
+    source="2C:CF:67:1B:03:3A",
+)
+
+INVALID_TP972 = make_bluetooth_service_info(
+    name="TP972S",
+    address="C3:18:C9:9C:C8:90",
+    rssi=-55,
+    manufacturer_data={
+        51138: b'\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8'
+    },
+    service_data={},
+    service_uuids=[],
+    source="2C:CF:67:1B:03:3A",
+)
+
+# Nonexistent (at time of writing) device
+INVALID_DEVICE = make_bluetooth_service_info(
+    name="TP9000NOTHING",
+    address="C3:18:C9:9C:C8:90",
+    rssi=-55,
+    manufacturer_data={
+        51138: b'\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8'
     },
     service_data={},
     service_uuids=[],
@@ -1258,6 +1303,144 @@ def test_tp970r():
     )
 
 
+def test_tp972s():
+    parser = ThermoProBluetoothDeviceData()
+    assert parser.update(TP972S) == SensorUpdate(
+        title="TP972S EEFF",
+        devices={
+            None: SensorDeviceInfo(
+                name="TP972S",
+                model="TP972S",
+                manufacturer="ThermoPro",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(
+                key="internal_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(
+                key="ambient_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                name="Probe 1 Battery",
+                native_value=90.0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-75,
+            ),
+            DeviceKey(key="internal_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                name="Probe 1 Internal Temperature",
+                native_value=33,
+            ),
+            DeviceKey(key="ambient_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                name="Probe 1 Ambient Temperature",
+                native_value=60,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+    assert parser.update(TP972S_2) == SensorUpdate(
+        title="TP972S EEFF",
+        devices={
+            None: SensorDeviceInfo(
+                name="TP972S",
+                model="TP972S",
+                manufacturer="ThermoPro",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(
+                key="internal_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+            DeviceKey(
+                key="ambient_temperature_probe_1", device_id=None
+            ): SensorDescription(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                device_class=SensorDeviceClass.TEMPERATURE,
+                native_unit_of_measurement=Units.TEMP_CELSIUS,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="battery_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="battery_probe_1", device_id=None),
+                name="Probe 1 Battery",
+                native_value=95.0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-75,
+            ),
+            DeviceKey(key="internal_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(
+                    key="internal_temperature_probe_1", device_id=None
+                ),
+                name="Probe 1 Internal Temperature",
+                native_value=74,
+            ),
+            DeviceKey(key="ambient_temperature_probe_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="ambient_temperature_probe_1", device_id=None),
+                name="Probe 1 Ambient Temperature",
+                native_value=87,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
 def test_tp357s_four_updates():
     parser = ThermoProBluetoothDeviceData()
 
@@ -1463,6 +1646,55 @@ def test_tp357s_four_updates():
                 name="Humidity",
                 native_value=10,
             ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
+def test_parser_error_1():
+    parser = ThermoProBluetoothDeviceData()
+    assert parser.update(INVALID_TP972) == SensorUpdate(
+        title="TP972S C890",
+        devices={
+            None: SensorDeviceInfo(
+                name="TP972S",
+                model="TP972S",
+                manufacturer="ThermoPro",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal Strength",
+                native_value=-55,
+            ),
+        },
+        binary_entity_descriptions={},
+        binary_entity_values={},
+        events={},
+    )
+
+
+def test_parser_error_2():
+    parser = ThermoProBluetoothDeviceData()
+    assert parser.update(INVALID_DEVICE) == SensorUpdate(
+        title=None,
+        devices={
+        },
+        entity_descriptions={
+        },
+        entity_values={
         },
         binary_entity_descriptions={},
         binary_entity_values={},

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+from bleak.backends.device import BLEDevice
 from bluetooth_data_tools import monotonic_time_coarse
 from bluetooth_sensor_state_data import SensorUpdate
 from sensor_state_data import (
@@ -12,7 +13,6 @@ from sensor_state_data import (
 )
 from thermopro_ble.parser import ThermoProBluetoothDeviceData
 
-from bleak.backends.device import BLEDevice
 from habluetooth import BluetoothServiceInfoBleak
 
 
@@ -1303,7 +1303,7 @@ def test_tp970r():
     )
 
 
-def test_tp972s():
+def test_tp972s() -> None:
     parser = ThermoProBluetoothDeviceData()
     assert parser.update(TP972S) == SensorUpdate(
         title="TP972S EEFF",
@@ -1653,7 +1653,7 @@ def test_tp357s_four_updates():
     )
 
 
-def test_parser_error_1():
+def test_parser_error_1() -> None:
     parser = ThermoProBluetoothDeviceData()
     assert parser.update(INVALID_TP972) == SensorUpdate(
         title="TP972S C890",
@@ -1686,7 +1686,7 @@ def test_parser_error_1():
     )
 
 
-def test_parser_error_2():
+def test_parser_error_2() -> None:
     parser = ThermoProBluetoothDeviceData()
     assert parser.update(INVALID_DEVICE) == SensorUpdate(
         title=None,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -288,7 +288,7 @@ TP972S = make_bluetooth_service_info(
 )
 TP972S_2 = make_bluetooth_service_info(
     name="TP972S",
-    manufacturer_data={36096: b'\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8'},
+    manufacturer_data={36096: b"\x00\xa6\n\xcd\xec\xffB\x9ai\x00C\x9ai\x00ClTswD\xf8"},
     service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
     address="aa:bb:cc:dd:ee:ff",
     rssi=-75,
@@ -424,7 +424,7 @@ INVALID_TP972 = make_bluetooth_service_info(
     address="C3:18:C9:9C:C8:90",
     rssi=-55,
     manufacturer_data={
-        51138: b'\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8'
+        51138: b"\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8"
     },
     service_data={},
     service_uuids=[],
@@ -437,7 +437,7 @@ INVALID_DEVICE = make_bluetooth_service_info(
     address="C3:18:C9:9C:C8:90",
     rssi=-55,
     manufacturer_data={
-        51138: b'\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8'
+        51138: b"\x01\x8d\x00\xe1\n3\x13\xfaB\x00\xc0\xfaB\x9a\xf9\xfaBlTswD\xf8"
     },
     service_data={},
     service_uuids=[],
@@ -1690,12 +1690,9 @@ def test_parser_error_2():
     parser = ThermoProBluetoothDeviceData()
     assert parser.update(INVALID_DEVICE) == SensorUpdate(
         title=None,
-        devices={
-        },
-        entity_descriptions={
-        },
-        entity_values={
-        },
+        devices={},
+        entity_descriptions={},
+        entity_values={},
         binary_entity_descriptions={},
         binary_entity_values={},
         events={},


### PR DESCRIPTION
Looking at the data stream, the TP972S appears to supply a 23-byte format: 0: 0-index of probe
 1: 2-byte short ambient temp + 54
 3: 2-byte battery level (kept same calculation as for TP96x)
 5: 4-byte float for min internal temp read
 9: 4 byte float for internal temp read
13: 4-byte float for max internal temp read
17: 6-byte ID
Increased unit test coverage