### PR TITLE
chore(parser): skip updates for ThermoPro BLE advertisements without …

### DIFF
--- a/src/thermopro_ble/device.py
+++ b/src/thermopro_ble/device.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from datetime import datetime
 from struct import pack
 from uuid import UUID
 
 from bleak import BleakClient
+from bleak.exc import BleakError
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
@@ -56,4 +58,5 @@ class ThermoProDevice:
                 True,
             )
         finally:
-            await client.disconnect()
+            with suppress(BleakError):
+                await client.disconnect()

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -81,6 +81,12 @@ class ThermoProBluetoothDeviceData(BluetoothData):
         """Update from BLE advertisement data."""
         _LOGGER.debug("Parsing thermopro BLE advertisement data: %s", service_info)
         name = service_info.name
+        if not name:
+            _LOGGER.debug(
+                "Skipping ThermoPro BLE advertisement without a device name: %s",
+                service_info,
+            )
+            return
         if not name.startswith(("TP35", "TP39", "TP96", "TP97")):
             return
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,6 +63,16 @@ TP357 = make_bluetooth_service_info(
     source="local",
 )
 
+TP357_NO_NAME = make_bluetooth_service_info(
+    name=None,
+    manufacturer_data={61890: b"\x00\x1d\x02,"},
+    service_uuids=[],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-60,
+    service_data={},
+    source="local",
+)
+
 
 TP357_RAW = make_bluetooth_service_info(
     name="TP357 (2142)",
@@ -449,6 +459,11 @@ def test_supported_set_the_title():
     parser = ThermoProBluetoothDeviceData()
     assert parser.supported(TP357) is True
     assert parser.title == "TP357 (2142) EEFF"
+
+
+def test_skip_update_when_name_missing():
+    parser = ThermoProBluetoothDeviceData()
+    assert parser.update(TP357_NO_NAME) == SensorUpdate()
 
 
 def test_tp357():


### PR DESCRIPTION
…a device name

chore(device): suppress BleakError during client disconnection
test: add test for skipping updates when device name is missing