### PR TITLE
fix: battery level parsing for TP357S

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -149,13 +149,15 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             )
             return
 
-        # TP357S seems to be in 6, TP397 and TP393 in 4
+        # TP357S, TP397 and TP393
         if data_length >= 6 and name.startswith("TP3"):
-            battery_byte = data[6] if data_length == 7 else data[4]
-            if battery_byte in BATTERY_VALUE_TO_LEVEL:
+            # battery value is represented by the lower two bits of byte 4
+            # (verified with TP357S on laboratory power supply)
+            battery_value = data[4] & 3
+            if battery_value in BATTERY_VALUE_TO_LEVEL:
                 self.update_predefined_sensor(
                     SensorLibrary.BATTERY__PERCENTAGE,
-                    BATTERY_VALUE_TO_LEVEL[battery_byte],
+                    BATTERY_VALUE_TO_LEVEL[battery_value],
                 )
 
             (temp, humi) = UNPACK_TEMP_HUMID(data[1:4])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -940,7 +940,7 @@ def test_tp357s():
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=50,
+                native_value=100,
             ),
         },
         binary_entity_descriptions={},
@@ -998,7 +998,7 @@ def test_tp357s():
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=50,
+                native_value=100,
             ),
         },
         binary_entity_descriptions={},
@@ -1521,7 +1521,7 @@ def test_tp357s_four_updates():
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=50,
+                native_value=100,
             ),
             DeviceKey(key="humidity", device_id=None): SensorValue(
                 device_key=DeviceKey(key="humidity", device_id=None),
@@ -1570,7 +1570,7 @@ def test_tp357s_four_updates():
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=50,
+                native_value=100,
             ),
             DeviceKey(key="signal_strength", device_id=None): SensorValue(
                 device_key=DeviceKey(key="signal_strength", device_id=None),
@@ -1639,7 +1639,7 @@ def test_tp357s_four_updates():
             DeviceKey(key="battery", device_id=None): SensorValue(
                 device_key=DeviceKey(key="battery", device_id=None),
                 name="Battery",
-                native_value=50,
+                native_value=100,
             ),
             DeviceKey(key="humidity", device_id=None): SensorValue(
                 device_key=DeviceKey(key="humidity", device_id=None),


### PR DESCRIPTION
This is a suggestion to fix TP357S battery level parsing. I've stumbled upon this potential bug while searching for some inspiration on implementing a component for the [esphome](https://github.com/esphome/esphome) project.

I've verified the battery data with a TP357S hooked up to a laboratory power supply and gradually reducing the voltage.

Not sure about the test data; I've assumed a full battery on the device as they were captured.