### PR TITLE
fix: support 13-byte TP96/TP97 probe packets with appended MAC trailer

### DIFF
--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -183,15 +183,18 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             )
             return
 
-        if data_length == 7 and name.startswith(("TP96", "TP97")):
+        if data_length in (7, 13) and name.startswith(("TP96", "TP97")):
             # TP96 has a different format that is shared with TP970
             # It has an internal temp probe and an ambient temp probe
+            # Some probes append 6 extra bytes (observed to be the reversed
+            # base-station MAC address) after the standard 7-byte payload,
+            # yielding 13 bytes total. The extra bytes are ignored.
             (
                 probe_zero_indexed,
                 internal_temp,
                 battery_voltage,
                 ambient_temp,
-            ) = UNPACK_SPIKE_TEMP(data)
+            ) = UNPACK_SPIKE_TEMP(data[:7])
 
             probe_one_indexed = probe_zero_indexed + 1
             internal_temp = internal_temp - 30

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -456,6 +456,80 @@ TP357S_UPDATE_4 = make_bluetooth_service_info(
     source="2C:CF:67:1B:03:3A",
 )
 
+# Mixed probe format fixtures for TP972S.
+# The probe index is encoded in the first LE byte of the manufacturer data key
+# (0x00 = probe 1, 0x01 = probe 2). Two wire formats can appear on the same device:
+#   23-byte: multi-point probe (tip/center/end temps) — mfr_id LE byte[0] encodes probe index
+#   13-byte: simple probe — identical <BHHH> payload as the 7-byte TP96 format with
+#            6 extra bytes appended; mfr_id for probe 1 = 0x3300, probe 2 = 0x3301
+
+# 13-byte probe 1 only
+TP972S_13B_PROBE1 = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={13056: b"\x00\x48\x0a\x33\x00\xff\xee\xdd\xcc\xbb\xaa"},
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
+# Probe 1 (13-byte) + probe 2 (13-byte) — probe 2 is new in this advertisement
+TP972S_13B_BOTH = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={
+        13056: b"\x00\x48\x0a\x33\x00\xff\xee\xdd\xcc\xbb\xaa",
+        13057: b"\x00\x48\x0a\x33\x00\xff\xee\xdd\xcc\xbb\xaa",
+    },
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
+# Probe 1 (23-byte) + probe 2 (23-byte) — probe 2 (mfr_id 29185) is new
+TP972S_23B_BOTH = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={
+        29184: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8",
+        29185: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8",
+    },
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
+# Probe 1 (13-byte) + probe 2 (23-byte multi-point) — probe 2 is new
+TP972S_13B_P1_23B_P2 = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={
+        13056: b"\x00\x48\x0a\x33\x00\xff\xee\xdd\xcc\xbb\xaa",
+        29185: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8",
+    },
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
+# Probe 1 (23-byte multi-point) + probe 2 (13-byte) — probe 2 is new
+TP972S_23B_P1_13B_P2 = make_bluetooth_service_info(
+    name="TP972S",
+    manufacturer_data={
+        29184: b"\x00j\n3\xd3\xb8B\x00@\xaeBf\x06\xaeBlTswD\xf8",
+        13057: b"\x00\x48\x0a\x33\x00\xff\xee\xdd\xcc\xbb\xaa",
+    },
+    service_uuids=["72fbb631-6f6b-d1ba-db55-2ee6fdd942bd"],
+    address="aa:bb:cc:dd:ee:ff",
+    rssi=-75,
+    service_data={},
+    source="local",
+)
+
 INVALID_TP972 = make_bluetooth_service_info(
     name="TP972S",
     address="C3:18:C9:9C:C8:90",
@@ -1985,3 +2059,77 @@ def test_parser_error_2() -> None:
         binary_entity_values={},
         events={},
     )
+
+
+def test_tp972s_both_probes_13byte() -> None:
+    """Both probe slots use the 13-byte format (TP96-style payload + reversed MAC)."""
+    parser = ThermoProBluetoothDeviceData()
+
+    result = parser.update(TP972S_13B_PROBE1)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 21
+    assert vals[DeviceKey(key="ambient_temperature_probe_1", device_id=None)].native_value == 21
+    assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
+
+    result = parser.update(TP972S_13B_BOTH)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 21
+    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 21
+    # 13-byte format only has internal + ambient; no center/end sensors
+    assert DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    assert DeviceKey(key="internal_end_temperature_probe_2", device_id=None) not in vals
+
+
+def test_tp972s_both_probes_23byte() -> None:
+    """Both probe slots use the 23-byte multi-point format."""
+    parser = ThermoProBluetoothDeviceData()
+
+    result = parser.update(TP972S)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 3.6
+    assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
+
+    result = parser.update(TP972S_23B_BOTH)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 3.6
+    assert vals[DeviceKey(key="internal_center_temperature_probe_2", device_id=None)].native_value == 0.6
+    assert vals[DeviceKey(key="internal_end_temperature_probe_2", device_id=None)].native_value == 0.6
+    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 15
+
+
+def test_tp972s_probe1_13byte_probe2_23byte() -> None:
+    """Probe 1 uses 13-byte format; probe 2 uses 23-byte multi-point format."""
+    parser = ThermoProBluetoothDeviceData()
+
+    result = parser.update(TP972S_13B_PROBE1)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 21
+    # 13-byte probe 1 has no center/end temperature sensors
+    assert DeviceKey(key="internal_center_temperature_probe_1", device_id=None) not in vals
+
+    result = parser.update(TP972S_13B_P1_23B_P2)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 3.6
+    assert vals[DeviceKey(key="internal_center_temperature_probe_2", device_id=None)].native_value == 0.6
+    assert vals[DeviceKey(key="internal_end_temperature_probe_2", device_id=None)].native_value == 0.6
+    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 15
+
+
+def test_tp972s_probe1_23byte_probe2_13byte() -> None:
+    """Probe 1 uses 23-byte multi-point format; probe 2 uses 13-byte format."""
+    parser = ThermoProBluetoothDeviceData()
+
+    result = parser.update(TP972S)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 3.6
+    assert vals[DeviceKey(key="internal_center_temperature_probe_1", device_id=None)].native_value == 0.6
+    assert vals[DeviceKey(key="internal_end_temperature_probe_1", device_id=None)].native_value == 0.6
+    assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
+
+    result = parser.update(TP972S_23B_P1_13B_P2)
+    vals = result.entity_values
+    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 21
+    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 21
+    # 13-byte replacement probe has no center/end temperature sensors
+    assert DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    assert DeviceKey(key="internal_end_temperature_probe_2", device_id=None) not in vals

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -459,7 +459,8 @@ TP357S_UPDATE_4 = make_bluetooth_service_info(
 # Mixed probe format fixtures for TP972S.
 # The probe index is encoded in the first LE byte of the manufacturer data key
 # (0x00 = probe 1, 0x01 = probe 2). Two wire formats can appear on the same device:
-#   23-byte: multi-point probe (tip/center/end temps) — mfr_id LE byte[0] encodes probe index
+#   23-byte: multi-point probe (tip/center/end temps) — mfr_id LE byte[0] encodes
+#            probe index
 #   13-byte: simple probe — identical <BHHH> payload as the 7-byte TP96 format with
 #            6 extra bytes appended; mfr_id for probe 1 = 0x3300, probe 2 = 0x3301
 
@@ -2067,16 +2068,30 @@ def test_tp972s_both_probes_13byte() -> None:
 
     result = parser.update(TP972S_13B_PROBE1)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 21
-    assert vals[DeviceKey(key="ambient_temperature_probe_1", device_id=None)].native_value == 21
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value
+        == 21
+    )
+    assert (
+        vals[DeviceKey(key="ambient_temperature_probe_1", device_id=None)].native_value
+        == 21
+    )
     assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
 
     result = parser.update(TP972S_13B_BOTH)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 21
-    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 21
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value
+        == 21
+    )
+    assert (
+        vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value
+        == 21
+    )
     # 13-byte format only has internal + ambient; no center/end sensors
-    assert DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    assert (
+        DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    )
     assert DeviceKey(key="internal_end_temperature_probe_2", device_id=None) not in vals
 
 
@@ -2086,15 +2101,34 @@ def test_tp972s_both_probes_23byte() -> None:
 
     result = parser.update(TP972S)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 3.6
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value
+        == 3.6
+    )
     assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
 
     result = parser.update(TP972S_23B_BOTH)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 3.6
-    assert vals[DeviceKey(key="internal_center_temperature_probe_2", device_id=None)].native_value == 0.6
-    assert vals[DeviceKey(key="internal_end_temperature_probe_2", device_id=None)].native_value == 0.6
-    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 15
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value
+        == 3.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_center_temperature_probe_2", device_id=None)
+        ].native_value
+        == 0.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_end_temperature_probe_2", device_id=None)
+        ].native_value
+        == 0.6
+    )
+    assert (
+        vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value
+        == 15
+    )
 
 
 def test_tp972s_probe1_13byte_probe2_23byte() -> None:
@@ -2103,16 +2137,37 @@ def test_tp972s_probe1_13byte_probe2_23byte() -> None:
 
     result = parser.update(TP972S_13B_PROBE1)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 21
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value
+        == 21
+    )
     # 13-byte probe 1 has no center/end temperature sensors
-    assert DeviceKey(key="internal_center_temperature_probe_1", device_id=None) not in vals
+    assert (
+        DeviceKey(key="internal_center_temperature_probe_1", device_id=None) not in vals
+    )
 
     result = parser.update(TP972S_13B_P1_23B_P2)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 3.6
-    assert vals[DeviceKey(key="internal_center_temperature_probe_2", device_id=None)].native_value == 0.6
-    assert vals[DeviceKey(key="internal_end_temperature_probe_2", device_id=None)].native_value == 0.6
-    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 15
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value
+        == 3.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_center_temperature_probe_2", device_id=None)
+        ].native_value
+        == 0.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_end_temperature_probe_2", device_id=None)
+        ].native_value
+        == 0.6
+    )
+    assert (
+        vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value
+        == 15
+    )
 
 
 def test_tp972s_probe1_23byte_probe2_13byte() -> None:
@@ -2121,15 +2176,36 @@ def test_tp972s_probe1_23byte_probe2_13byte() -> None:
 
     result = parser.update(TP972S)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value == 3.6
-    assert vals[DeviceKey(key="internal_center_temperature_probe_1", device_id=None)].native_value == 0.6
-    assert vals[DeviceKey(key="internal_end_temperature_probe_1", device_id=None)].native_value == 0.6
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_1", device_id=None)].native_value
+        == 3.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_center_temperature_probe_1", device_id=None)
+        ].native_value
+        == 0.6
+    )
+    assert (
+        vals[
+            DeviceKey(key="internal_end_temperature_probe_1", device_id=None)
+        ].native_value
+        == 0.6
+    )
     assert DeviceKey(key="internal_temperature_probe_2", device_id=None) not in vals
 
     result = parser.update(TP972S_23B_P1_13B_P2)
     vals = result.entity_values
-    assert vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value == 21
-    assert vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value == 21
+    assert (
+        vals[DeviceKey(key="internal_temperature_probe_2", device_id=None)].native_value
+        == 21
+    )
+    assert (
+        vals[DeviceKey(key="ambient_temperature_probe_2", device_id=None)].native_value
+        == 21
+    )
     # 13-byte replacement probe has no center/end temperature sensors
-    assert DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    assert (
+        DeviceKey(key="internal_center_temperature_probe_2", device_id=None) not in vals
+    )
     assert DeviceKey(key="internal_end_temperature_probe_2", device_id=None) not in vals


### PR DESCRIPTION
---

### Problem

Some TP96/TP97-family probes (observed on TP972S) send a 13-byte manufacturer data packet
instead of the expected 7-byte format. The 13-byte variant uses the identical `<BHHH>`
payload (probe index, internal temperature, battery voltage, ambient temperature) but
appends 6 extra bytes — the reversed base-station MAC address — as a trailer.

Before this fix, 13-byte packets fell through all three length checks in `_start_update`
and were logged as parse errors:

```
ERROR [thermopro_ble.parser] Error parsing data from probe: b'\x01\x33\x00\x48...'
```

No `SensorUpdate` was emitted, so the probe channel appeared offline or retained stale
values from a previous session indefinitely.

### Affected scenarios

**Scenario 1 — Replacement probe not recognized after hardware failure**

A TP972S with two probes had its original Probe 2 (23-byte multi-point format) fail and
get replaced. The replacement probe advertises in the 13-byte format. After the swap, Home
Assistant stopped updating Probe 2 and continued showing the last temperature reading from
the dead probe — because the new probe's packets were silently dropped. The replacement
probe is a genuine ThermoPro probe; it functions correctly on the base station display,
just not with the TP97-only 23-byte parser path.

**Scenario 2 — Second probe never discovered on a different unit**

A second TP972S that had previously lost a probe entirely only ever showed one probe in
Home Assistant. After this fix, the second probe's channel was automatically discovered
with no user intervention required.

Both scenarios confirm that the 13-byte format is not limited to aftermarket or replacement
hardware — it appears to be the standard BLE advertisement format for at least one hardware
revision of the TP972S single-point probe.

### Fix

Extend the existing 7-byte TP96/TP97 branch to also accept 13-byte packets, and slice
`data[:7]` before unpacking so the 6-byte trailer is ignored:

```python
# was: data_length == 7
if data_length in (7, 13) and name.startswith(("TP96", "TP97")):
    ...
    ) = UNPACK_SPIKE_TEMP(data[:7])   # was: UNPACK_SPIKE_TEMP(data)
```

### Tests

Four new tests cover all combinations of 7/13-byte and 23-byte probes across the two
channels of a TP972S (both-13b, both-23b, 13b+23b, 23b+13b). All existing tests pass
unchanged.

### Verification

Confirmed working on physical hardware:
- TP972S with a 23-byte Probe 1 and a 13-byte replacement Probe 2 — both channels report
  live temperatures correctly after the fix.
- A second TP972S with only 13-byte probes — both channels discovered and reporting
  correctly with no manual re-configuration.
