### PR TITLE
feat(parser): add TP59 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ have decoders with test coverage:
 | ------- | ------------------------------ | --------------------------------------------------- |
 | `TP35x` | TP357, TP357S, TP358, TP358S   | Temperature, humidity, battery                      |
 | `TP39x` | TP393                          | Temperature, humidity, battery                      |
+| `TP59`  | TP59                           | Temperature, humidity, battery                      |
 | `TP96x` | TP960R, TP962R (TempSpike)     | Internal/ambient probe temperature, battery         |
 | `TP97x` | TP970R, TP972S (TempSpike Pro) | Tip/center/end probe temperatures, ambient, battery |
 

--- a/src/thermopro_ble/parser.py
+++ b/src/thermopro_ble/parser.py
@@ -127,7 +127,7 @@ class ThermoProBluetoothDeviceData(BluetoothData):
         """Update from BLE advertisement data."""
         _LOGGER.debug("Parsing thermopro BLE advertisement data: %s", service_info)
         name = service_info.name
-        if not name.startswith(("TP35", "TP39", "TP96", "TP97")):
+        if not name.startswith(("TP35", "TP39", "TP59", "TP96", "TP97")):
             return
 
         model = name.split(" ")[0]
@@ -205,8 +205,8 @@ class ThermoProBluetoothDeviceData(BluetoothData):
             )
             return
 
-        # TP357S, TP397 and TP393
-        if data_length >= 6 and name.startswith("TP3"):
+        # TP357S, TP397, TP393 and TP59 all share the same frame format
+        if data_length >= 6 and name.startswith(("TP3", "TP59")):
             # battery value is represented by the lower two bits of byte 4
             # (verified with TP357S on laboratory power supply)
             battery_value = data[4] & 3

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -220,6 +220,29 @@ TP358S = make_bluetooth_service_info(
     source="local",
 )
 
+# TP59 shares the TP35x advertisement format and parser path. These fixtures
+# use real captured advertisements from two physical TP59 units (one with
+# freshly replaced batteries, one drained) to lock in support for the model.
+TP59 = make_bluetooth_service_info(
+    name="TP59 (8C7B)",
+    manufacturer_data={62402: b"\x00\x30\x02\x2c"},
+    service_uuids=[],
+    address="48:7e:48:f1:8c:7b",
+    rssi=-60,
+    service_data={},
+    source="local",
+)
+
+TP59_LOW_BATTERY = make_bluetooth_service_info(
+    name="TP59 (6906)",
+    manufacturer_data={56002: b"\x00\x31\x00\x2c"},
+    service_uuids=[],
+    address="48:7e:48:f1:69:06",
+    rssi=-60,
+    service_data={},
+    source="local",
+)
+
 
 TP393_DETECT_CHANGED_1 = make_bluetooth_service_info(
     name="TP393 (9376)",
@@ -738,6 +761,45 @@ def test_tp358s_model():
     assert (
         update.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
         == 29
+    )
+
+
+def test_tp59_model():
+    """TP59 shares the TP35x frame format and should be parsed as model TP59."""
+    parser = ThermoProBluetoothDeviceData()
+    update = parser.update(TP59)
+    assert update.devices[None].model == "TP59"
+    assert update.devices[None].name == "TP59 (8C7B)"
+    assert (
+        update.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 24.3
+    )
+    assert (
+        update.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 48
+    )
+    assert (
+        update.entity_values[DeviceKey(key="battery", device_id=None)].native_value
+        == 100
+    )
+
+
+def test_tp59_low_battery():
+    """A second physical TP59, with drained cells, decodes a low battery level."""
+    parser = ThermoProBluetoothDeviceData()
+    update = parser.update(TP59_LOW_BATTERY)
+    assert update.devices[None].model == "TP59"
+    assert update.devices[None].name == "TP59 (6906)"
+    assert (
+        update.entity_values[DeviceKey(key="temperature", device_id=None)].native_value
+        == 21.8
+    )
+    assert (
+        update.entity_values[DeviceKey(key="humidity", device_id=None)].native_value
+        == 49
+    )
+    assert (
+        update.entity_values[DeviceKey(key="battery", device_id=None)].native_value == 1
     )
 
 


### PR DESCRIPTION
## Summary

Adds support for the ThermoPro TP59, whose BLE advertisements use the same frame format as the already-supported TP357/TP357S/TP393 family — `Struct("<hB")` for temperature/humidity, plus the 2-bit battery level at `data[4] & 3`.

Two guards needed widening, and the second is easy to miss:

1. The top-level model guard `name.startswith(("TP35", "TP39", "TP96", "TP97"))` — now includes `"TP59"`.
2. The shared TP35x decode branch, which was `name.startswith("TP3")` and does **not** match `"TP59"` — now `name.startswith(("TP3", "TP59"))`.

Without the second change a TP59 passes the first guard, matches no decode branch, and hits `_LOGGER.error("Error parsing data from probe")` on every advertisement.

## Evidence

Three live advertisements, decoded with this library's own `UNPACK_TEMP_HUMID` and `BATTERY_VALUE_TO_LEVEL`, on frames built as `company_id (2 bytes LE) + payload`:

| Device | Frame | Decoded |
|---|---|---|
| TP359 (3DED) — already supported, used as a control | `c2e7002b022c` | 23.1 °C, 43 %, battery 100 % |
| TP59 (8C7B) | `c2f30030022c` | 24.3 °C, 48 %, battery 100 % |
| TP59 (6906) | `c2da0031002c` | 21.8 °C, 49 %, battery 1 % |

The battery values are the strongest evidence. The owner had just replaced the cells in one TP59 and not the other, and that was never supplied to the decoder — it independently produced 100 % for the re-batteried unit and 1 % for the drained one, from the raw bytes alone.

Both units have since run for hours in a live Home Assistant instance through a local custom integration using this decode path, alongside the TP359 control. All three report plausible, room-appropriate readings that track their environments.

## What was *not* established

An exact frame-for-frame match against the known-good TP359's live Home Assistant reading, captured from *outside* the integration, was never reproduced. These devices rotate several manufacturer-data company IDs per cycle, and on the capture host `service_info.raw` was empty, so `changed_manufacturer_data`'s selection could not be replicated by an external script to pick the current id deterministically. The frames above decode correctly and the values are stable across hours of live operation, but I would rather flag that gap than imply a stronger check than was done.

## Testing

Added `test_tp59_model` and `test_tp59_low_battery` to `tests/test_parser.py`, built from the two real captured frames above. Full `test_parser.py` suite passes, including all pre-existing TP357/TP358/TP393/TP96x/TP97x tests — no regression from widening the guards. Also added a row to the README's supported-devices table.

## Notes for reviewers

- Draft PR #177 (typed model registry + README table) overlaps slightly: if it lands first, TP59 should be added to `thermopro_ble.models` as well. Happy to rebase onto it or fold this in, whichever you prefer.
- A companion `home-assistant/core` change (a `TP59*` bluetooth matcher plus a requirement bump) is prepared but deliberately **not** opened yet — it is blocked on this merging and releasing. On its own it would make HA discover TP59 devices and decode nothing, since this library's guard rejects the name first.
